### PR TITLE
keepconf fails on [files] items with capital letters

### DIFF
--- a/latest/keepconf
+++ b/latest/keepconf
@@ -452,6 +452,7 @@ def main():
                 vprint('Reading host config file:', i)
                 try:
                     parser = ConfigParser(allow_no_value=True)
+                    parser.optionxform = str
                     parser.read(i)
                 except Exception as e:
                     sys.exit('ERROR reading host config file: '+ str(e))
@@ -519,6 +520,7 @@ def main():
 
                     try:  # read cfg file
                         parser = ConfigParser(allow_no_value=True)
+                        parser.optionxform = str
                         parser.read(j)
                     except Exception as e:
                         sys.exit('ERROR reading cfg file: '+j+' '+ str(e))


### PR DESCRIPTION
Currently capital letters in [files] items are ignored by keepconf. Reason for this is that ConfigParser automatically lowercases those entries. On a case sensitive file system this causes trouble. This simple change fixes this.

See also:
http://stackoverflow.com/questions/1611799/preserve-case-in-configparser
